### PR TITLE
fr24feed: add enable-log control and fr24feed-status

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,17 @@ Use `snap services adsb-box` to check the overview of adsb-box services.
 
 ### fr24feed status
 
-If fr24feed is configured correctly, you can find the web here `http://your-device-ip:8754/`.
+If fr24feed is configured correctly, you can find the web here `http://your-device-ip:8754/`. Another CLI tool `fr24feed-status` can show a summary. Here is an example output.
+
+``` sh
+$ adsb-box.fr24feedcli
+FR24 Feeder/Decoder Process is running
+FR24 Stats Timestamp: 2019-05-31 00:00:00
+FR24 Link: connected [UDP]
+FR24 Radar: T-RXYZ99
+FR24 Tracked AC: 1
+Receiver: connected (813 MSGS/0 SYNC)
+```
 
 ### pfclient status
 

--- a/bin/fr24feed
+++ b/bin/fr24feed
@@ -1,8 +1,18 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 set -x
 
+BIN="$SNAP/usr/bin/fr24feed"
+
+WORKDIR="$SNAP_DATA/fr24feed"
+PIDFILE="$WORKDIR/fr24feed.pid"
+MONITORFILE="/tmp/fr24feed.txt"
+
 #export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/usr/lib
+
+[ ! -d "$WORKDIR" ] && mkdir "$WORKDIR"
+# fr24feed.ini migration
+[ -f "$SNAP_DATA/fr24feed.ini" ] && mv "$SNAP_DATA/fr24feed.ini" "$WORKDIR/fr24feed.ini"
 
 if [ ! -f /etc/fr24feed.ini ]; then
 	touch /etc/fr24feed.ini
@@ -13,4 +23,16 @@ if [ "$(grep -c fr24key= /etc/fr24feed.ini)" -ne 1 ]; then
 	exit
 fi
 
-"$SNAP/usr/bin/fr24feed"
+ARGS=("--monitor-file=$MONITORFILE" "--write-pid=$PIDFILE")
+
+ENABLE_LOG=$(snapctl get fr24feed.enable-log)
+case "$ENABLE_LOG" in
+	1|[Oo][Nn]|[Tt][Rr][Uu][Ee])
+		;;
+	*)
+		# disable log
+		ARGS+=("--quiet")
+		;;
+esac
+
+$BIN "${ARGS[@]}"

--- a/bin/fr24feed
+++ b/bin/fr24feed
@@ -12,7 +12,10 @@ MONITORFILE="/tmp/fr24feed.txt"
 
 [ ! -d "$WORKDIR" ] && mkdir "$WORKDIR"
 # fr24feed.ini migration
-[ -f "$SNAP_DATA/fr24feed.ini" ] && mv "$SNAP_DATA/fr24feed.ini" "$WORKDIR/fr24feed.ini"
+if [ -f "$SNAP_DATA/fr24feed.ini" ]; then
+	cp "$SNAP_DATA/fr24feed.ini" "$WORKDIR/fr24feed.ini"
+	rm "$SNAP_DATA/fr24feed.ini"
+fi
 
 if [ ! -f /etc/fr24feed.ini ]; then
 	touch /etc/fr24feed.ini

--- a/bin/fr24feed-status
+++ b/bin/fr24feed-status
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# ported from /etc/init.d/fr24feed carried in fr24feed.deb
+
+set -e
+#set -x
+
+# From bin/fr24feed
+WORKDIR="$SNAP_DATA/fr24feed"
+PIDFILE="$WORKDIR/fr24feed.pid"
+MONITORFILE="/tmp/fr24feed.txt"
+
+FR24PID=$(cat "$PIDFILE" 2>/dev/null)
+
+if [ "$FR24PID" = "" ] || [ ! -d "/proc/${FR24PID}" ]; then
+	 "FR24 Feeder/Decoder Process is not running"
+	exit 1
+else
+	echo "FR24 Feeder/Decoder Process is running"
+fi
+
+DATE=$(grep time_update_utc_s= $MONITORFILE 2>/dev/null | cut -d'=' -f2)
+echo "FR24 Stats Timestamp: $DATE"
+
+FEED=$(grep 'feed_status=' $MONITORFILE 2>/dev/null | cut -d'=' -f2)
+[ "$FEED" = "" ] && FEED="unknown"
+
+if [ "$FEED" = "connected" ]; then
+	MODE=$(grep feed_current_mode= $MONITORFILE 2>/dev/null | cut -d'=' -f2)
+	echo "FR24 Link: $FEED [$MODE]"
+	FEED=$(grep feed_alias= $MONITORFILE 2>/dev/null | cut -d'=' -f2)
+	echo "FR24 Radar: $FEED"
+	FEED=$(grep feed_num_ac_tracked= $MONITORFILE 2>/dev/null | cut -d'=' -f2)
+	FEED=${FEED:-0}
+	echo "FR24 Tracked AC: ${FEED}"
+else
+	echo "FR24 Link: $FEED"
+fi
+
+RX=$(grep rx_connected= $MONITORFILE 2>/dev/null | cut -d'=' -f2)
+
+if [ "$RX" = "1" ]; then
+	RX1=$(grep num_messages= $MONITORFILE 2>/dev/null | cut -d'=' -f2)
+	RX1=${RX1:-0}
+	RX2=$(grep num_resyncs= $MONITORFILE 2>/dev/null | cut -d'=' -f2)
+	RX2=${RX2:-0}
+	echo "Receiver: connected ($RX1 MSGS/$RX2 SYNC)"
+else
+	echo "Receiver: down"
+fi
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -302,7 +302,7 @@ parts:
 passthrough:
   layout:
     /etc/fr24feed.ini:
-      bind-file: $SNAP_DATA/fr24feed.ini
+      bind-file: $SNAP_DATA/fr24feed/fr24feed.ini
     /var/lib/openskyd:
       bind: $SNAP_DATA/openskyd
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,6 +33,8 @@ apps:
   fr24feedcli:
     command: bin/fr24feedcli
     plugs: [network, network-bind, network-observe]
+  fr24feed-status:
+    command: bin/fr24feed-status
   openskyd:
     command: bin/openskyd
     daemon: simple


### PR DESCRIPTION
This PR is to:
  1. add the enable-log control to enable/disable the log of fr24feed
  2. add arguments for the pid file and the monitor file
  2. since fr24feed now writes the monitor (status) file, add fr24feed-status to show a summary.