### PR TITLE
Move runtime RRD files to tmpfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,20 @@ $ snap set adsb-box collectd.rrd-random-timeout=0
 $ snap set adsb-box collectd.rrd-writes-per-second=80
 ```
 
+Another method to reduce the number of Disk I/O is moving the rrd files to tmpfs. This implementation will:
+1. when collectd starts, copy rrd files from `$SNAP_COMMON/collectd/rrd` to `/tmp/rrd` which is located on tmpfs.
+2. periodically sync the rrd files back to `$SNAP_COMMON/collectd/rrd` according to the config value.
+3. when collectd shuts down, sync the rrd files again.
+The method has a drawback. If the system does not shut down properly (e.g. power outage), the records will be lost. Maximum duration is equal to the period configured.
+To enable this feature:
+``` sh
+# unit of period is second
+$ snap set adsb-box collectd.rrd-backup-period=1800
+# restart related services
+$ snap restart adsb-box.collectd
+$ snap restart adsb-box.graphs-gend
+```
+
 ### dump1090
 
 The configuration of dump1090 is at `/var/snap/adsb-box/<rev>/dump1090-fa.conf`.

--- a/bin/collectd
+++ b/bin/collectd
@@ -8,7 +8,8 @@ LOGFILE=$WORKDIR/collectd.log
 PIDFILE=$WORKDIR/collectd.pid
 BIN=$SNAP/usr/sbin/collectd
 BASEDIR=$SNAP_COMMON/collectd
-RRDDIR=$BASEDIR/rrd
+RRDDIR_DISK="$BASEDIR/rrd"
+RRDDIR_RAM=/tmp/rrd
 DISKFILE=$SNAP_DATA/disk.conf
 DISK=
 MOUNTPOINT=
@@ -19,7 +20,25 @@ export PYTHONPATH=$SNAP/usr/lib/python2.7
 LC_ALL=C.UTF-8
 LANG=C.UTF-8
 
-mkdir -p "$BASEDIR" "$RRDDIR" "$WORKDIR"
+trap 'rrd-op backup' EXIT
+
+[ ! -d "$BASEDIR" ] && mkdir -p "$BASEDIR"
+[ ! -d "$WORKDIR" ] && mkdir -p "$WORKDIR"
+
+PERIOD_BACKUP=$(snapctl get collectd.rrd-backup-period)
+PERIOD_BACKUP=${PERIOD_BACKUP:-0}
+if [ "$PERIOD_BACKUP" -ne 0 ]; then
+	# Restore RRD files from disk
+	rrd-op restore
+	RRDDIR="$RRDDIR_RAM"
+else
+	# Move files on RAM back to disk
+	if [ -d "$RRDDIR_RAM" ]; then
+		rrd-op backup
+		rm -rf "$RRDDIR_RAM"
+	fi
+	RRDDIR="$RRDDIR_DISK"
+fi
 
 # Migration
 [ -f "$SNAP_DATA/collectd.conf" ] && rm "$SNAP_DATA/collectd.conf"

--- a/bin/graphs-gend
+++ b/bin/graphs-gend
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+set -x
 
 # delay for dump1090 and collectd
 sleep 3
@@ -21,6 +23,7 @@ TIMEOUT_24h=0
 TIMEOUT_7d=0
 TIMEOUT_30d=0
 TIMEOUT_365d=0
+TIMEOUT_BACKUP=0
 
 PERIOD_1h=300
 PERIOD_6h=600
@@ -34,12 +37,15 @@ OFFSET_7d=240
 OFFSET_30d=360
 OFFSET_365d=480
 
+PERIOD_BACKUP=$(snapctl get collectd.rrd-backup-period)
+PERIOD_BACKUP=${PERIOD_BACKUP:-0}
+
 # create output directory which is defined in make-collectd-graphs.sh
 mkdir -p /tmp/graphs
 
 gen_graphs()
 {
-	echo ["$(date +"%Y%m%d%H%M%S")"] run cmd, arg="$*"
+	echo "[$(date +"%F %T")] run cmd, arg=$*"
 	nice -n 5 "$SNAP/usr/share/adsb-receiver/graphs/make-collectd-graphs.sh" "$@" >/dev/null 2>&1
 }
 
@@ -59,6 +65,10 @@ init_timeouts()
 	TIMEOUT_30d=$((now-mod+OFFSET_30d))
 	mod=$((now%PERIOD_365d))
 	TIMEOUT_365d=$((now-mod+OFFSET_365d))
+	if [ "$PERIOD_BACKUP" -ne 0 ]; then
+		# backup is not necessary at the beginning
+		TIMEOUT_BACKUP=$((now+PERIOD_BACKUP))
+	fi
 }
 
 init_timeouts
@@ -100,6 +110,12 @@ while true; do
 	if [ "$now" -ge "$TIMEOUT_365d" ]; then
 		gen_graphs 365d &
 		TIMEOUT_365d=$((TIMEOUT_365d+PERIOD_365d))
+	fi
+
+	## Backup work
+	if [ "$PERIOD_BACKUP" -ne 0 ] && [ "$now" -ge "$TIMEOUT_BACKUP" ]; then
+		rrd-op backup &
+		TIMEOUT_BACKUP=$((TIMEOUT_BACKUP+PERIOD_BACKUP))
 	fi
 
 	sleep 30

--- a/bin/rrd-op
+++ b/bin/rrd-op
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -ex
+
+BASEDIR="$SNAP_COMMON/collectd/rrd"
+RRDDIR="/tmp/rrd"
+
+restore()
+{
+	TS="$SECONDS"
+	echo "[$(date +"%F %T")] restore started."
+	if [ ! -d "$RRDDIR" ]; then
+		mkdir -p "$RRDDIR"
+		if [ -d "$BASEDIR/localhost" ]; then
+			cp -a "$BASEDIR"/localhost "$RRDDIR/"
+		fi
+	else
+		echo "Restoration is skipped."
+	fi
+	echo "[$(date +"%F %T")] restore done. duration=$((SECONDS-TS))sec"
+}
+
+backup()
+{
+	TS="$SECONDS"
+	echo "[$(date +"%F %T")] backup started."
+	cd /tmp/rrd || return
+	while IFS= read -r -d '' ent; do
+		if [ -d "$ent" ]; then
+			mkdir -p "/tmp/rrd.new/$ent"
+		elif [ "${ent: -4}" = ".rrd" ]; then
+			#rrdtool dump "$ent" | rrdtool restore - "/tmp/rrd.new/$ent"
+			cp "$ent" "/tmp/rrd.new/$ent"
+		fi
+	done <  <(find . -print0)
+	cp -a /tmp/rrd.new/localhost "$BASEDIR/"
+	rm -rf /tmp/rrd.new
+	echo "[$(date +"%F %T")] backup done. duration=$((SECONDS-TS))sec"
+}
+
+usage()
+{
+	echo "Usage: $0 [backup|restore]"
+}
+
+case "$1" in
+	"restore")
+		restore
+		;;
+	"backup")
+		backup
+		;;
+	*)
+		usage
+		exit 1
+esac

--- a/patches/graphs-gend.patch
+++ b/patches/graphs-gend.patch
@@ -1,8 +1,8 @@
 diff --git a/build/portal/graphs/make-collectd-graphs.sh b/build/portal/graphs/make-collectd-graphs.sh
-index 6094805..0bb5119 100755
+index 6094805..bfcf5bc 100755
 --- a/build/portal/graphs/make-collectd-graphs.sh
 +++ b/build/portal/graphs/make-collectd-graphs.sh
-@@ -1,16 +1,35 @@
+@@ -1,16 +1,45 @@
  #!/bin/bash
  
 +export XDG_DATA_HOME=$SNAP/usr/share
@@ -29,6 +29,16 @@ index 6094805..0bb5119 100755
 -RAWDOCUMENTROOT=`/usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf -p | grep server.document-root`
 -DOCUMENTROOT=`sed 's/.*"\(.*\)"[^"]*$/\1/' <<< $RAWDOCUMENTROOT`
 +DOCUMENTROOT=/tmp
++
++RRDDIR_DISK="$BASEDIR/rrd"
++RRDDIR_RAM=/tmp/rrd
++PERIOD_BACKUP=$(snapctl get collectd.rrd-backup-period)
++PERIOD_BACKUP=${PERIOD_BACKUP:-0}
++if [ "$PERIOD_BACKUP" -ne 0 ]; then
++	RRDDIR="$RRDDIR_RAM"
++else
++	RRDDIR="$RRDDIR_DISK"
++fi
  
 -renice -n 5 -p $$
 +#renice -n 5 -p $$
@@ -42,7 +52,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 480 \
    --height 200 \
-@@ -32,12 +51,13 @@ aircraft_graph() {
+@@ -32,12 +61,13 @@ aircraft_graph() {
    "LINE1:pos#0000FF:w/ Positions" \
    "LINE1:noloc#FF0000:w/o Positions" \
    "LINE1:mlat#000000:mlat" \
@@ -58,7 +68,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 428 \
    --height 200 \
-@@ -62,12 +82,13 @@ aircraft_message_rate_graph() {
+@@ -62,12 +92,13 @@ aircraft_message_rate_graph() {
    "LINE1:maxrate#FF0000:Maximum" \
    "GPRINT:maxrate:%3.1lf\c" \
    "LINE1:aircrafts10#990000:Aircraft Seen / Tracked (RHS) \c" \
@@ -74,7 +84,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 480 \
    --height 200 \
-@@ -86,12 +107,13 @@ cpu_graph_dump1090() {
+@@ -86,12 +117,13 @@ cpu_graph_dump1090() {
    "AREA:backgroundp#00C000:Other:STACK" \
    "AREA:demodp#00FF00:Demodulator\c:STACK" \
    "COMMENT: \n" \
@@ -90,7 +100,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 480 \
    --height 200 \
-@@ -107,14 +129,15 @@ tracks_graph() {
+@@ -107,14 +139,15 @@ tracks_graph() {
    "AREA:hsingle#FF0000:Tracks with single message" \
    "AREA:hall#00FF00:Unique tracks\c:STACK" \
    "COMMENT: \n" \
@@ -108,7 +118,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 1010 \
    --height 200 \
-@@ -147,12 +170,13 @@ cpu_graph() {
+@@ -147,12 +180,13 @@ cpu_graph() {
    "AREA:psystem#FF0000:sys:STACK" \
    "AREA:puser#40FF40:user:STACK" \
    "AREA:pnice#008000:nice\c:STACK" \
@@ -124,7 +134,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 496 \
    --height 200 \
-@@ -168,12 +192,13 @@ df_root_graph() {
+@@ -168,12 +202,13 @@ df_root_graph() {
    "AREA:totalused#4169E1:Used:STACK" \
    "AREA:free#32C734:Free\c:STACK" \
    "COMMENT: \n" \
@@ -140,7 +150,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 480 \
    --height 200 \
-@@ -195,12 +220,13 @@ disk_io_iops_graph() {
+@@ -195,12 +230,13 @@ disk_io_iops_graph() {
    "GPRINT:write:MAX:Max\:%4.1lf iops" \
    "GPRINT:write:AVERAGE:Avg\:%4.1lf iops" \
    "GPRINT:write:LAST:Current\:%4.1lf iops\c" \
@@ -156,7 +166,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 480 \
    --height 200 \
-@@ -222,12 +248,13 @@ disk_io_octets_graph() {
+@@ -222,12 +258,13 @@ disk_io_octets_graph() {
    "GPRINT:write:MAX:Max\: %4.1lf %sB/sec" \
    "GPRINT:write:AVERAGE:Avg\: %4.1lf %SB/sec" \
    "GPRINT:write:LAST:Current\: %4.1lf %SB/sec\c" \
@@ -172,7 +182,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 480 \
    --height 200 \
-@@ -248,12 +275,13 @@ eth0_graph() {
+@@ -248,12 +285,13 @@ eth0_graph() {
    "GPRINT:tx:MAX:Max\:%8.1lf %S" \
    "GPRINT:tx:AVERAGE:Avg\:%8.1lf %S" \
    "GPRINT:tx:LAST:Current\:%8.1lf %Sbytes/sec\c" \
@@ -188,7 +198,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 496 \
    --height 200 \
-@@ -271,12 +299,13 @@ memory_graph() {
+@@ -271,12 +309,13 @@ memory_graph() {
    "AREA:cached#00FF00:Cached:STACK" \
    "AREA:free#FFFFFF:Free\c:STACK" \
    "COMMENT: \n" \
@@ -204,7 +214,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 480 \
    --height 200 \
-@@ -294,12 +323,13 @@ temp_graph_imperial() {
+@@ -294,12 +333,13 @@ temp_graph_imperial() {
    "AREA:ttc#ffcc00" \
    "COMMENT: \n" \
    "COMMENT: \n" \
@@ -220,7 +230,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 480 \
    --height 200 \
-@@ -315,12 +345,13 @@ temp_graph_metric() {
+@@ -315,12 +355,13 @@ temp_graph_metric() {
    "AREA:tfin#ffcc00" \
    "COMMENT: \n" \
    "COMMENT: \n" \
@@ -236,7 +246,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 480 \
    --height 200 \
-@@ -341,14 +372,15 @@ wlan0_graph() {
+@@ -341,14 +382,15 @@ wlan0_graph() {
    "GPRINT:tx:MAX:Max\:%8.1lf %S" \
    "GPRINT:tx:AVERAGE:Avg\:%8.1lf %S" \
    "GPRINT:tx:LAST:Current\:%8.1lf %Sbytes/sec\c" \
@@ -254,7 +264,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 429 \
    --height 200 \
-@@ -367,12 +399,13 @@ local_rate_graph() {
+@@ -367,12 +409,13 @@ local_rate_graph() {
    "AREA:y2strong#FF0000:Messages > -3dBFS / 10min (RHS)" \
    "LINE1:y2positions#00c0FF:Positions / Hr (RHS)\c" \
    "COMMENT: \n" \
@@ -270,7 +280,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 959 \
    --height 200 \
-@@ -480,12 +513,13 @@ local_trailing_rate_graph() {
+@@ -480,12 +523,13 @@ local_trailing_rate_graph() {
    "AREA:y2strong#FF0000:Messages > -3dBFS/10min (RHS)\g" \
    "GPRINT:strong_percent_vdef: (%1.1lf<span font='2'> </span>%% of messages)" \
    "LINE1:y2positions#00c0FF:Positions/Hr (RHS)\c" \
@@ -286,7 +296,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 428 \
    --height 200 \
-@@ -506,12 +540,13 @@ range_graph_imperial_nautical(){
+@@ -506,12 +550,13 @@ range_graph_imperial_nautical(){
    "LINE1:peakrange#FF0000:Peak Range\\:" \
    "GPRINT:peakrange:%1.1lf NM\c" \
    "COMMENT: \n" \
@@ -302,7 +312,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 428 \
    --height 200 \
-@@ -532,12 +567,13 @@ range_graph_imperial_statute(){
+@@ -532,12 +577,13 @@ range_graph_imperial_statute(){
    "LINE1:peakrange#FF0000:Peak Range\\:" \
    "GPRINT:peakrange:%1.1lf SM\c" \
    "COMMENT: \n" \
@@ -318,7 +328,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 428 \
    --height 200 \
-@@ -557,12 +593,13 @@ range_graph_metric() {
+@@ -557,12 +603,13 @@ range_graph_metric() {
    "LINE1:peakrange#FF0000:Peak Range\\:" \
    "GPRINT:peakrange:%1.1lf km\c" \
    "COMMENT: \n" \
@@ -334,7 +344,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 480 \
    --height 186 \
-@@ -589,14 +626,15 @@ signal_graph() {
+@@ -589,14 +636,15 @@ signal_graph() {
    "GPRINT:noise:AVERAGE:Avg\: %4.1lf\c" \
    "LINE1:0#000000:Zero dBFS" \
    "LINE1:-3#FF0000:-3 dBFS\c" \
@@ -352,7 +362,7 @@ index 6094805..0bb5119 100755
    --start end-$4 \
    --width 480 \
    --height 200 \
-@@ -611,44 +649,45 @@ remote_rate_graph() {
+@@ -611,44 +659,45 @@ remote_rate_graph() {
    "CDEF:y2positions=positions,10,*" \
    "LINE1:messages#0000FF:messages received" \
    "LINE1:y2positions#00c0FF:position / hr (RHS)" \
@@ -367,10 +377,10 @@ index 6094805..0bb5119 100755
 -  aircraft_message_rate_graph ${DOCUMENTROOT}/graphs/dump1090-$2-aircraft_message_rate-$4.png /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
 -  cpu_graph_dump1090 ${DOCUMENTROOT}/graphs/dump1090-$2-cpu-$4.png /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
 -  tracks_graph ${DOCUMENTROOT}/graphs/dump1090-$2-tracks-$4.png /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5" 
-+  aircraft_graph ${DOCUMENTROOT}/graphs/dump1090-$2-aircraft-$4.png $SNAP_COMMON/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
-+  aircraft_message_rate_graph ${DOCUMENTROOT}/graphs/dump1090-$2-aircraft_message_rate-$4.png $SNAP_COMMON/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
-+  cpu_graph_dump1090 ${DOCUMENTROOT}/graphs/dump1090-$2-cpu-$4.png $SNAP_COMMON/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
-+  tracks_graph ${DOCUMENTROOT}/graphs/dump1090-$2-tracks-$4.png $SNAP_COMMON/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
++  aircraft_graph ${DOCUMENTROOT}/graphs/dump1090-$2-aircraft-$4.png ${RRDDIR}/$1/dump1090-$2 "$3" "$4" "$5"
++  aircraft_message_rate_graph ${DOCUMENTROOT}/graphs/dump1090-$2-aircraft_message_rate-$4.png ${RRDDIR}/$1/dump1090-$2 "$3" "$4" "$5"
++  cpu_graph_dump1090 ${DOCUMENTROOT}/graphs/dump1090-$2-cpu-$4.png ${RRDDIR}/$1/dump1090-$2 "$3" "$4" "$5"
++  tracks_graph ${DOCUMENTROOT}/graphs/dump1090-$2-tracks-$4.png ${RRDDIR}/$1/dump1090-$2 "$3" "$4" "$5"
  }
  
  system_graphs() {
@@ -383,15 +393,15 @@ index 6094805..0bb5119 100755
 -  temp_graph_imperial ${DOCUMENTROOT}/graphs/system-$2-temperature_imperial-$4.png /var/lib/collectd/rrd/$1/table-$2 "$3" "$4" "$5"
 -  temp_graph_metric ${DOCUMENTROOT}/graphs/system-$2-temperature_metric-$4.png /var/lib/collectd/rrd/$1/table-$2 "$3" "$4" "$5"
 -  wlan0_graph ${DOCUMENTROOT}/graphs/system-$2-wlan0_bandwidth-$4.png /var/lib/collectd/rrd/$1/interface-wlan0 "$3" "$4" "$5"
-+  cpu_graph ${DOCUMENTROOT}/graphs/system-$2-cpu-$4.png $SNAP_COMMON/collectd/rrd/$1/aggregation-cpu-average "$3" "$4" "$5"
-+  df_root_graph ${DOCUMENTROOT}/graphs/system-$2-df_root-$4.png $SNAP_COMMON/collectd/rrd/$1/df-$MOUNTPOINT "$3" "$4" "$5"
-+  disk_io_iops_graph ${DOCUMENTROOT}/graphs/system-$2-disk_io_iops-$4.png $SNAP_COMMON/collectd/rrd/$1/disk-$DISK "$3" "$4" "$5"
-+  disk_io_octets_graph ${DOCUMENTROOT}/graphs/system-$2-disk_io_octets-$4.png $SNAP_COMMON/collectd/rrd/$1/disk-$DISK "$3" "$4" "$5"
-+  eth0_graph ${DOCUMENTROOT}/graphs/system-$2-eth0_bandwidth-$4.png $SNAP_COMMON/collectd/rrd/$1/interface-eth0 "$3" "$4" "$5"
-+  memory_graph ${DOCUMENTROOT}/graphs/system-$2-memory-$4.png $SNAP_COMMON/collectd/rrd/$1/memory "$3" "$4" "$5"
-+  temp_graph_imperial ${DOCUMENTROOT}/graphs/system-$2-temperature_imperial-$4.png $SNAP_COMMON/collectd/rrd/$1/table-$2 "$3" "$4" "$5"
-+  temp_graph_metric ${DOCUMENTROOT}/graphs/system-$2-temperature_metric-$4.png $SNAP_COMMON/collectd/rrd/$1/table-$2 "$3" "$4" "$5"
-+  wlan0_graph ${DOCUMENTROOT}/graphs/system-$2-wlan0_bandwidth-$4.png $SNAP_COMMON/collectd/rrd/$1/interface-wlan0 "$3" "$4" "$5"
++  cpu_graph ${DOCUMENTROOT}/graphs/system-$2-cpu-$4.png ${RRDDIR}/$1/aggregation-cpu-average "$3" "$4" "$5"
++  df_root_graph ${DOCUMENTROOT}/graphs/system-$2-df_root-$4.png ${RRDDIR}/$1/df-$MOUNTPOINT "$3" "$4" "$5"
++  disk_io_iops_graph ${DOCUMENTROOT}/graphs/system-$2-disk_io_iops-$4.png ${RRDDIR}/$1/disk-$DISK "$3" "$4" "$5"
++  disk_io_octets_graph ${DOCUMENTROOT}/graphs/system-$2-disk_io_octets-$4.png ${RRDDIR}/$1/disk-$DISK "$3" "$4" "$5"
++  eth0_graph ${DOCUMENTROOT}/graphs/system-$2-eth0_bandwidth-$4.png ${RRDDIR}/$1/interface-eth0 "$3" "$4" "$5"
++  memory_graph ${DOCUMENTROOT}/graphs/system-$2-memory-$4.png ${RRDDIR}/$1/memory "$3" "$4" "$5"
++  temp_graph_imperial ${DOCUMENTROOT}/graphs/system-$2-temperature_imperial-$4.png ${RRDDIR}/$1/table-$2 "$3" "$4" "$5"
++  temp_graph_metric ${DOCUMENTROOT}/graphs/system-$2-temperature_metric-$4.png ${RRDDIR}/$1/table-$2 "$3" "$4" "$5"
++  wlan0_graph ${DOCUMENTROOT}/graphs/system-$2-wlan0_bandwidth-$4.png ${RRDDIR}/$1/interface-wlan0 "$3" "$4" "$5"
  }
  
  dump1090_receiver_graphs() {
@@ -403,19 +413,19 @@ index 6094805..0bb5119 100755
 -  range_graph_imperial_statute ${DOCUMENTROOT}/graphs/dump1090-$2-range_imperial_statute-$4.png /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
 -  range_graph_metric ${DOCUMENTROOT}/graphs/dump1090-$2-range_metric-$4.png /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
 -  signal_graph ${DOCUMENTROOT}/graphs/dump1090-$2-signal-$4.png /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
-+  local_rate_graph ${DOCUMENTROOT}/graphs/dump1090-$2-local_rate-$4.png $SNAP_COMMON/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
-+  local_trailing_rate_graph ${DOCUMENTROOT}/graphs/dump1090-$2-local_trailing_rate-$4.png $SNAP_COMMON/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
-+  range_graph_imperial_nautical ${DOCUMENTROOT}/graphs/dump1090-$2-range_imperial_nautical-$4.png $SNAP_COMMON/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
-+  range_graph_imperial_statute ${DOCUMENTROOT}/graphs/dump1090-$2-range_imperial_statute-$4.png $SNAP_COMMON/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
-+  range_graph_metric ${DOCUMENTROOT}/graphs/dump1090-$2-range_metric-$4.png $SNAP_COMMON/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
-+  signal_graph ${DOCUMENTROOT}/graphs/dump1090-$2-signal-$4.png $SNAP_COMMON/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
++  local_rate_graph ${DOCUMENTROOT}/graphs/dump1090-$2-local_rate-$4.png ${RRDDIR}/$1/dump1090-$2 "$3" "$4" "$5"
++  local_trailing_rate_graph ${DOCUMENTROOT}/graphs/dump1090-$2-local_trailing_rate-$4.png ${RRDDIR}/$1/dump1090-$2 "$3" "$4" "$5"
++  range_graph_imperial_nautical ${DOCUMENTROOT}/graphs/dump1090-$2-range_imperial_nautical-$4.png ${RRDDIR}/$1/dump1090-$2 "$3" "$4" "$5"
++  range_graph_imperial_statute ${DOCUMENTROOT}/graphs/dump1090-$2-range_imperial_statute-$4.png ${RRDDIR}/$1/dump1090-$2 "$3" "$4" "$5"
++  range_graph_metric ${DOCUMENTROOT}/graphs/dump1090-$2-range_metric-$4.png ${RRDDIR}/$1/dump1090-$2 "$3" "$4" "$5"
++  signal_graph ${DOCUMENTROOT}/graphs/dump1090-$2-signal-$4.png ${RRDDIR}/$1/dump1090-$2 "$3" "$4" "$5"
  }
  
  dump1090_hub_graphs() {
    dump1090_graphs "$1" "$2" "$3" "$4" "$5"
    system_graphs "$1" "$2" "$3" "$4" "$5"
 -  remote_rate_graph ${DOCUMENTROOT}/graphs/dump1090-$2-remote_rate-$4.png /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
-+  remote_rate_graph ${DOCUMENTROOT}/graphs/dump1090-$2-remote_rate-$4.png $SNAP_COMMON/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
++  remote_rate_graph ${DOCUMENTROOT}/graphs/dump1090-$2-remote_rate-$4.png ${RRDDIR}/$1/dump1090-$2 "$3" "$4" "$5"
  }
  
  period="$1"


### PR DESCRIPTION
### Description
The collectd updates RRD files several times every minute. Although we can use the cache mechanism of rrdtool plugin, I still want to reduce the number of writing.
This commit introduces a new configuration item `collectd.rrd-backup-period`. If the value is non-zero, the programs will put the runtime rrd files into tmpfs and backup them to the original place periodically.

### Test builds:
* [amd64](https://launchpad.net/~robertliu/+snap/adsb-box+test-build/+build/626829)
* [i386](https://launchpad.net/~robertliu/+snap/adsb-box+test-build/+build/626828)
* [armhf](https://launchpad.net/~robertliu/+snap/adsb-box+test-build/+build/626830)
* [arm64](https://launchpad.net/~robertliu/+snap/adsb-box+test-build/+build/626831)

### Graphs
* Disk I/O bandwidth: no apparent difference
![system-localhost-disk_io_octets-7d](https://user-images.githubusercontent.com/19427605/61768608-8a0cfb00-ae1a-11e9-9a51-f3eebc0ee13a.png)
* Disk IOPS: reduced from 1.1 to 0.1
![system-localhost-disk_io_iops-7d](https://user-images.githubusercontent.com/19427605/61768610-8aa59180-ae1a-11e9-9291-518dcfa979f0.png)
* CPU usage: io ratio is almost 0
![system-localhost-cpu-7d](https://user-images.githubusercontent.com/19427605/61768690-bc1e5d00-ae1a-11e9-9830-aa84224cc0ef.png)
