### PR TITLE
rbfeeder: fix /var/run/sanp.adsb-box creation failures

### DIFF
--- a/bin/rbfeeder
+++ b/bin/rbfeeder
@@ -16,7 +16,7 @@ WORKDIR="$SNAP_DATA/rbfeeder"
 RBFEEDER_INI="$WORKDIR/rbfeeder.ini"
 
 [ ! -d "$WORKDIR" ] && mkdir "$WORKDIR"
-[ ! -d "/var/run/snap.$SNAP_NAME" ] && mkdir -p "/var/run/snap.$SNAP_NAME"
+[ ! -d "/run/snap.$SNAP_NAME" ] && mkdir "/run/snap.$SNAP_NAME"
 
 if [ ! -f "$RBFEEDER_INI" ]; then
 	cp "$SNAP/etc/rbfeeder.ini" "$RBFEEDER_INI"


### PR DESCRIPTION
It's not necessary to create parent directory. If use the '-p' option,
mkdir will fail, because snapd redirects the access.