### PR TITLE
fix issues of fr24feed 1.0.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,15 +239,17 @@ Question | Answer | Note
 -|-|-
 email address | email_address | your email address on FR24
 sharing key | sharying_key | If you ever share your day, find it on FR24 web
-participate MLAT | yes_or_no (up to you) | If yes, need to specify your coordinates
+participate MLAT | yes_or_no (up to you) | On amd64/i386, MLAT is not supported, please answer **no**. If yes, need to specify your coordinates
 automatically configure dump1090 | no |
 receiver type | 4 | ModeS Beast
 connection type | 1 | network connection
-receiver address | localhost |
+receiver address | 127.0.0.1 | On amd64/i386, please don't use _localhost_
 receiver port | 30005 |
 enable RAW data feed | yes |
 enable Basestation data feed | yes |
 logfile mode | 0 | disable
+
+There are some known issues on amd64/i386 platform, see the [post](https://forum.flightradar24.com/forum/radar-forums/flightradar24-feeding-data-to-flightradar24/12639-1-0-24-5-amd64-error) for detail.
 
 If you want to modify the configurations later, please use:
 ``` sh

--- a/bin/fr24feed
+++ b/bin/fr24feed
@@ -10,6 +10,7 @@ BIN="$SNAP/usr/bin/fr24feed"
 WORKDIR="$SNAP_DATA/fr24feed"
 PIDFILE="$WORKDIR/fr24feed.pid"
 MONITORFILE="/tmp/fr24feed.txt"
+CONF="/etc/fr24feed.ini"
 
 #export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/usr/lib
 
@@ -20,13 +21,35 @@ if [ -f "$SNAP_DATA/fr24feed.ini" ]; then
 	rm "$SNAP_DATA/fr24feed.ini"
 fi
 
-if [ ! -f /etc/fr24feed.ini ]; then
-	touch /etc/fr24feed.ini
+if [ ! -f "$CONF" ]; then
+	touch "$CONF"
 fi
 
-if [ "$(grep -c fr24key= /etc/fr24feed.ini)" -ne 1 ]; then
+if [ "$(grep -c fr24key= "$CONF")" -ne 1 ]; then
 	echo fr24feed is not configured yet ...
 	exit
+fi
+
+# on amd64 and i386, not use localhost as hostname and no mlat
+if [ "$SNAP_ARCH" = "amd64" ] || [ "$SNAP_ARCH" = "i386" ]; then
+	UPDATE_CONF=0
+	NEW_CONF="/tmp/fr24feed.ini.tmp"
+	cp "$CONF" "$NEW_CONF"
+	if [ "$(grep -c "host=\"localhost:" "$NEW_CONF")" != 0 ]; then
+		sed -i 's/host="localhost:/host="127.0.0.1:/g' "$NEW_CONF"
+		UPDATE_CONF=1
+	fi
+	if [ "$(grep -c "mlat=\"yes\"" "$NEW_CONF")" != 0 ]; then
+		sed -i 's/mlat="yes"/mlat="no"/g' "$NEW_CONF"
+		UPDATE_CONF=1
+	fi
+	if [ "$(grep -c "mlat-without-gps=\"yes\"" "$NEW_CONF")" != 0 ]; then
+		sed -i 's/mlat-without-gps="yes"/mlat-without-gps="no"/g' "$NEW_CONF"
+		UPDATE_CONF=1
+	fi
+	if [ "$UPDATE_CONF" -eq 1 ]; then
+		cp "$NEW_CONF" "$CONF"
+	fi
 fi
 
 ARGS=("--monitor-file=$MONITORFILE" "--write-pid=$PIDFILE")
@@ -40,5 +63,7 @@ case "$ENABLE_LOG" in
 		ARGS+=("--quiet")
 		;;
 esac
+
+export TZ=GMT
 
 $BIN "${ARGS[@]}"

--- a/bin/fr24feedcli
+++ b/bin/fr24feedcli
@@ -2,10 +2,37 @@
 set -e
 set -x
 
+CONF="/etc/fr24feed.ini"
+
 #export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/usr/lib
 
-if [ ! -f /etc/fr24feed.ini ]; then
-	touch /etc/fr24feed.ini
+if [ ! -f "$CONF" ]; then
+	touch "$CONF"
 fi
 
+export TZ=GMT
+
 "$SNAP/usr/bin/fr24feed" "$@"
+
+# on amd64 and i386, not use localhost as hostname and no mlat
+if [ "$SNAP_ARCH" = "amd64" ] || [ "$SNAP_ARCH" = "i386" ]; then
+	UPDATE_CONF=0
+	NEW_CONF="/tmp/fr24feed.ini.tmp"
+	cp "$CONF" "$NEW_CONF"
+	if [ "$(grep -c "host=\"localhost:" "$NEW_CONF")" != 0 ]; then
+		sed -i 's/host="localhost:/host="127.0.0.1:/g' "$NEW_CONF"
+		UPDATE_CONF=1
+	fi
+	if [ "$(grep -c "mlat=\"yes\"" "$NEW_CONF")" != 0 ]; then
+		sed -i 's/mlat="yes"/mlat="no"/g' "$NEW_CONF"
+		UPDATE_CONF=1
+	fi
+	if [ "$(grep -c "mlat-without-gps=\"yes\"" "$NEW_CONF")" != 0 ]; then
+		sed -i 's/mlat-without-gps="yes"/mlat-without-gps="no"/g' "$NEW_CONF"
+		UPDATE_CONF=1
+	fi
+	if [ "$UPDATE_CONF" -eq 1 ]; then
+		cp "$NEW_CONF" "$CONF"
+	fi
+fi
+


### PR DESCRIPTION
fr24feed 1.0.24 doesn't support running MLAT on amd64/i386[1].
Need to disable MLAT on amd64/i386.
Also, if hostname of Beast source is localhost, the fr24feed will get SEGV
fault. Use 127.0.0.1 instead.

fr24feed wants to have time in GMT.