### PR TITLE
revert fr24feed on arm64 (github: #23)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -238,7 +238,7 @@ parts:
       - else:
         - on armhf: http://repo.feed.flightradar24.com/rpi_binaries/fr24feed_1.0.24-7_armhf.tgz
       - else:
-        - on arm64: http://repo.feed.flightradar24.com/rpi_binaries/fr24feed_1.0.24-7_armhf.tgz
+        - on arm64: http://repo.feed.flightradar24.com/rpi_binaries/fr24feed_1.0.23-8_armhf.tgz
       - else fail
     build-packages:
       - wget


### PR DESCRIPTION
The new fr24feed 1.0.24-7 might be terminated by "Bus error" signal on Arm64 platform. There is a [thread](https://forum.flightradar24.com/forum/radar-forums/flightradar24-feeding-data-to-flightradar24/12607-fr24-feeder-decoder-version-1-0-24-2-generic)[1] on Flightradar24 discussing this issue. At this moment, the only way is using the previous version. So this PR is to use the previous version of fr24feed for arm64.

[1] https://forum.flightradar24.com/forum/radar-forums/flightradar24-feeding-data-to-flightradar24/12607-fr24-feeder-decoder-version-1-0-24-2-generic