### PR TITLE
snapcraft.yaml: remove passthrough for after and layout

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,8 +23,7 @@ apps:
     command: bin/piaware
     daemon: simple
     plugs: [network, network-bind, system-observe, network-observe, mount-observe, hardware-observe]
-    passthrough:
-      after: [dump1090]
+    after: [dump1090]
   piaware-config:
     command: bin/piaware-config
   piaware-status:
@@ -34,8 +33,7 @@ apps:
     command: bin/fr24feed
     daemon: simple
     plugs: [network, network-bind, network-observe]
-    passthrough:
-      after: [dump1090]
+    after: [dump1090]
   fr24feedcli:
     command: bin/fr24feedcli
     plugs: [network, network-bind, network-observe]
@@ -45,14 +43,12 @@ apps:
     command: bin/openskyd
     daemon: simple
     plugs: [network, network-bind]
-    passthrough:
-      after: [dump1090]
+    after: [dump1090]
   pfclient:
     command: bin/pfclientd
     daemon: simple
     plugs: [network, network-bind]
-    passthrough:
-      after: [dump1090]
+    after: [dump1090]
   rtltest:
     command: usr/bin/rtl_test
     plugs: [network, network-bind, raw-usb, hardware-observe]
@@ -64,20 +60,17 @@ apps:
     command: bin/graphs-gend
     daemon: simple
     plugs: [process-control]
-    passthrough:
-      after: [dump1090, collectd, lighttpd]
+    after: [dump1090, collectd, lighttpd]
   adsbexchange-netcat:
     command: bin/adsbexchange-netcat
     daemon: simple
     plugs: [network, network-bind, network-observe]
-    passthrough:
-      after: [dump1090]
+    after: [dump1090]
   adsbexchange-mlat:
     command: bin/adsbexchange-mlat
     daemon: simple
     plugs: [network, network-bind, network-observe]
-    passthrough:
-      after: [dump1090]
+    after: [dump1090]
   rbfeeder:
     command: bin/rbfeeder
     daemon: simple
@@ -396,9 +389,8 @@ parts:
       cmake --build . --target install
 
 
-passthrough:
-  layout:
-    /etc/fr24feed.ini:
-      bind-file: $SNAP_DATA/fr24feed/fr24feed.ini
-    /var/lib/openskyd:
-      bind: $SNAP_DATA/openskyd
+layout:
+  /etc/fr24feed.ini:
+    bind-file: $SNAP_DATA/fr24feed/fr24feed.ini
+  /var/lib/openskyd:
+    bind: $SNAP_DATA/openskyd


### PR DESCRIPTION
No more passthrough keyword.