### PR TITLE
[fr24feed] update to 1.0.25-1 for armhf and arm64

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -229,9 +229,9 @@ parts:
       - else:
         - on i386: http://repo.feed.flightradar24.com/linux_x86_binaries/fr24feed_1.0.24-5_i386.tgz
       - else:
-        - on armhf: http://repo.feed.flightradar24.com/rpi_binaries/fr24feed_1.0.24-7_armhf.tgz
+        - on armhf: http://repo.feed.flightradar24.com/rpi_binaries/fr24feed_1.0.25-1_armhf.tgz
       - else:
-        - on arm64: http://repo.feed.flightradar24.com/rpi_binaries/fr24feed_1.0.23-8_armhf.tgz
+        - on arm64: http://repo.feed.flightradar24.com/rpi_binaries/fr24feed_1.0.25-1_armhf.tgz
       - else fail
     build-packages:
       - wget


### PR DESCRIPTION
According to [this comment](https://github.com/tsunghanliu/adsb-box.snap/issues/23#issuecomment-596563969), this version should fix 'bus error' on Arm64 platforms.