### PR TITLE
[fr24feed] update to 1.0.25-2 for amd64 and 1.0.25-1 for i386. [piaware] update to v3.8.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -110,7 +110,7 @@ parts:
     source: https://github.com/flightaware/dump1090.git
     source-type: git
     # the branch should be the same with piaware
-    source-branch: v3.8.0
+    source-branch: v3.8.1
     override-build: |
       echo 'patching dump1090 ...'
       if [ -n "$SNAPCRAFT_PROJECT_DIR" ]; then
@@ -172,7 +172,7 @@ parts:
     source: https://github.com/flightaware/piaware.git
     source-type: git
     # the branch should be the same with dump1090-fa
-    source-branch: v3.8.0
+    source-branch: v3.8.1
     override-build: |
       echo 'patching piaware ...'
       if [ -n "$SNAPCRAFT_PROJECT_DIR" ]; then
@@ -225,9 +225,9 @@ parts:
   fr24feed:
     plugin: dump
     source:
-      - on amd64: http://repo.feed.flightradar24.com/linux_x86_64_binaries/fr24feed_1.0.24-5_amd64.tgz
+      - on amd64: http://repo.feed.flightradar24.com/linux_x86_64_binaries/fr24feed_1.0.25-2_amd64.tgz
       - else:
-        - on i386: http://repo.feed.flightradar24.com/linux_x86_binaries/fr24feed_1.0.24-5_i386.tgz
+        - on i386: http://repo.feed.flightradar24.com/linux_x86_binaries/fr24feed_1.0.25-1_i386.tgz
       - else:
         - on armhf: http://repo.feed.flightradar24.com/rpi_binaries/fr24feed_1.0.25-1_armhf.tgz
       - else:


### PR DESCRIPTION
[fr24feed] Fixes 'Aircraft Uploaded' always zero bug