### PR TITLE
Revert rbfeeder to 0.2.21-20191004004313

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -328,7 +328,7 @@ parts:
       env | sort
       case $SNAPCRAFT_ARCH_TRIPLET in
         arm-*|aarch64-*)
-          wget -O rbfeeder.deb https://apt.rb24.com/pool/main/r/rbfeeder/rbfeeder_0.3.5-20200727132301_armhf.deb
+          wget -O rbfeeder.deb https://apt.rb24.com/pool/main/r/rbfeeder/rbfeeder_0.2.21-20191004004313_armhf.deb
           ;;
         *)
           echo "Unsupported architecture: $SNAPCRAFT_ARCH_TRIPLET"


### PR DESCRIPTION
This reverts commit b6c7842b9d1729ba07f9dc8f1b1d06739833fce9.

rbfeeder `0.3.5-20200727132301` requires libraries from a new release (maybe focal), so let's keep using the previous version `0.2.21-20191004004313` for now.

eventually, we should migrate to `core20`.