### PR TITLE
add flags for debug log enabling

### DIFF
--- a/bin/adsbexchange-mlat
+++ b/bin/adsbexchange-mlat
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
-set -x
+
+ENABLE_LOG=$(snapctl get adsbexchange.enable-log)
+ENABLE_LOG=${ENABLE_LOG:-0}
+if [ "$ENABLE_LOG" != "0" ]; then
+	set -x
+fi
 
 # delay for dump1090
 sleep 3

--- a/bin/adsbexchange-netcat
+++ b/bin/adsbexchange-netcat
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
-set -x
+
+ENABLE_LOG=$(snapctl get adsbexchange.enable-log)
+ENABLE_LOG=${ENABLE_LOG:-0}
+if [ "$ENABLE_LOG" != "0" ]; then
+	set -x
+fi
 
 # wait until all required interfaces are connected
 PLUGS="network-observe"

--- a/bin/collectd
+++ b/bin/collectd
@@ -1,6 +1,10 @@
 #! /bin/bash
 
-set -x
+ENABLE_LOG=$(snapctl get collectd.enable-log)
+ENABLE_LOG=${ENABLE_LOG:-0}
+if [ "$ENABLE_LOG" != "0" ]; then
+	set -x
+fi
 
 WORKDIR=$SNAP_DATA/collectd
 CONF=$WORKDIR/collectd.conf

--- a/bin/dump1090
+++ b/bin/dump1090
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
-#set -x
+
+ENABLE_LOG=$(snapctl get dump1090.enable-log)
+ENABLE_LOG=${ENABLE_LOG:-0}
+if [ "$ENABLE_LOG" != "0" ]; then
+	set -x
+fi
 
 BIN="$SNAP/usr/bin/dump1090-fa"
 ARGS=()

--- a/bin/dump978
+++ b/bin/dump978
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
-#set -x
+
+ENABLE_LOG=$(snapctl get dump978.enable-log)
+ENABLE_LOG=${ENABLE_LOG:-0}
+if [ "$ENABLE_LOG" != "0" ]; then
+	set -x
+fi
 
 # get index/serial of receiver
 dev_index=$(snapctl get receiver.dump978.index)

--- a/bin/fr24feed
+++ b/bin/fr24feed
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
-set -x
+
+ENABLE_LOG=$(snapctl get fr24feed.enable-log)
+ENABLE_LOG=${ENABLE_LOG:-0}
+if [ "$ENABLE_LOG" != "0" ]; then
+	set -x
+fi
 
 # delay for dump1090
 sleep 3
@@ -70,7 +75,6 @@ fi
 
 ARGS=("--monitor-file=$MONITORFILE" "--write-pid=$PIDFILE")
 
-ENABLE_LOG=$(snapctl get fr24feed.enable-log)
 case "$ENABLE_LOG" in
 	1|[Oo][Nn]|[Tt][Rr][Uu][Ee])
 		;;

--- a/bin/fr24feed-status
+++ b/bin/fr24feed-status
@@ -3,7 +3,12 @@
 # ported from /etc/init.d/fr24feed carried in fr24feed.deb
 
 set -e
-#set -x
+
+ENABLE_LOG=$(snapctl get fr24feed.enable-log)
+ENABLE_LOG=${ENABLE_LOG:-0}
+if [ "$ENABLE_LOG" != "0" ]; then
+	set -x
+fi
 
 # From bin/fr24feed
 WORKDIR="$SNAP_DATA/fr24feed"

--- a/bin/fr24feedcli
+++ b/bin/fr24feedcli
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
-#set -x
+
+ENABLE_LOG=$(snapctl get fr24feed.enable-log)
+ENABLE_LOG=${ENABLE_LOG:-0}
+if [ "$ENABLE_LOG" != "0" ]; then
+	set -x
+fi
 
 CONF="/etc/fr24feed.ini"
 

--- a/bin/graphs-gend
+++ b/bin/graphs-gend
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-#set -x
+ENABLE_LOG=$(snapctl get graphs-gend.enable-log)
+ENABLE_LOG=${ENABLE_LOG:-0}
+
+if [ "$ENABLE_LOG" != "0" ]; then
+	set -x
+fi
 
 # wait until all required interfaces are connected
 PLUGS="process-control"
@@ -69,7 +74,9 @@ mkdir -p /tmp/graphs
 
 gen_graphs()
 {
-	echo "[$(date +"%F %T")] run cmd, arg=$*"
+	if [ "$ENABLE_LOG" != "0" ]; then
+		echo "[$(date +"%F %T")] run cmd, arg=$*"
+	fi
 	nice -n 5 "$SNAP/usr/share/graphs1090/graphs1090.sh" "$1" 0.7 >/dev/null 2>&1
 }
 

--- a/bin/lighttpd
+++ b/bin/lighttpd
@@ -1,5 +1,11 @@
 #! /bin/sh
 
+ENABLE_LOG=$(snapctl get collectd.enable-log)
+ENABLE_LOG=${ENABLE_LOG:-0}
+if [ "$ENABLE_LOG" != "0" ]; then
+	set -x
+fi
+
 WORKDIR=$SNAP_DATA/lighttpd
 CONF=$WORKDIR/lighttpd.conf
 BIN=$SNAP/usr/sbin/lighttpd
@@ -122,7 +128,6 @@ accesslog.filename          = "$ACCESS_LOG"
 
 EOF
 
-ENABLE_LOG=$(snapctl get lighttpd.enable-localhost-log)
 case "$ENABLE_LOG" in
 	1|on|ON|true|TRUE)
 		# no restrictions of access logs

--- a/bin/openskyd
+++ b/bin/openskyd
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
-set -x
+
+ENABLE_LOG=$(snapctl get openskyd.enable-log)
+ENABLE_LOG=${ENABLE_LOG:-0}
+if [ "$ENABLE_LOG" != "0" ]; then
+	set -x
+fi
 
 # delay for dump1090
 sleep 3

--- a/bin/pfclientd
+++ b/bin/pfclientd
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
-set -x
+
+ENABLE_LOG=$(snapctl get plane-finder.enable-log)
+ENABLE_LOG=${ENABLE_LOG:-0}
+if [ "$ENABLE_LOG" != "0" ]; then
+	set -x
+fi
 
 # delay for dump1090
 sleep 3
@@ -21,7 +26,6 @@ fi
 
 ARGS=("-i" "$PIDFILE" "-z" "$CONFIGFILE")
 
-ENABLE_LOG=$(snapctl get plane-finder.enable-log)
 case "$ENABLE_LOG" in
 	1|on|ON|true|TRUE)
 		ARGS+=("-y" "$LOGDIR")

--- a/bin/piaware
+++ b/bin/piaware
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
-set -x
+
+ENABLE_LOG=$(snapctl get piaware.enable-log)
+ENABLE_LOG=${ENABLE_LOG:-0}
+if [ "$ENABLE_LOG" != "0" ]; then
+	set -x
+fi
 
 # delay for dump1090
 sleep 3
@@ -81,7 +86,6 @@ ARGS=("-p" "$PIDFILE"
 		"-cachedir" "$CACHEDIR"
 		"-statusfile" "$STATUSFILE")
 
-ENABLE_LOG=$(snapctl get piaware.enable-log)
 case "$ENABLE_LOG" in
 	1|on|ON|true|TRUE)
 		ARGS+=("-logfile" "$LOGFILE")

--- a/bin/piaware-config
+++ b/bin/piaware-config
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
-#set -x
+
+ENABLE_LOG=$(snapctl get piaware.enable-log)
+ENABLE_LOG=${ENABLE_LOG:-0}
+if [ "$ENABLE_LOG" != "0" ]; then
+	set -x
+fi
 
 #export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/usr/lib
 

--- a/bin/piaware-status
+++ b/bin/piaware-status
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
-#set -x
+
+ENABLE_LOG=$(snapctl get piaware.enable-log)
+ENABLE_LOG=${ENABLE_LOG:-0}
+if [ "$ENABLE_LOG" != "0" ]; then
+	set -x
+fi
 
 #export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/usr/lib
 

--- a/bin/rbfeeder
+++ b/bin/rbfeeder
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
-set -x
+
+ENABLE_LOG=$(snapctl get rbfeeder.enable-log)
+ENABLE_LOG=${ENABLE_LOG:-0}
+if [ "$ENABLE_LOG" != "0" ]; then
+	set -x
+fi
 
 BIN="$SNAP/usr/bin/rbfeeder"
 
@@ -36,8 +41,8 @@ RBFEEDER_INI="$WORKDIR/rbfeeder.ini"
 
 if [ ! -f "$RBFEEDER_INI" ]; then
 	cp "$SNAP/etc/rbfeeder.ini" "$RBFEEDER_INI"
-	sed -i 's/\/var\/log\/rbfeeder.log/\/dev\/null/' "$RBFEEDER_INI"
 fi
+sed -i 's/\/var\/log\/rbfeeder.log/\/dev\/null/' "$RBFEEDER_INI"
 
 if [ -n "$(snapctl get receiver.dump978.index)" ] || [ -n "$(snapctl get receiver.dump978.serial)" ]; then
 	# add dump978 settings

--- a/bin/rbfeeder-mlat
+++ b/bin/rbfeeder-mlat
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
-set -x
+
+ENABLE_LOG=$(snapctl get rbfeeder.enable-log)
+ENABLE_LOG=${ENABLE_LOG:-0}
+if [ "$ENABLE_LOG" != "0" ]; then
+	set -x
+fi
 
 if [ ! -f "$SNAP/usr/bin/rbfeeder" ]; then
 	echo "The rbfeeder does not exist. Maybe the architecture($SNAP_ARCH) is not supported."

--- a/bin/skyaware978
+++ b/bin/skyaware978
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
-#set -x
+
+ENABLE_LOG=$(snapctl get skyaware978.enable-log)
+ENABLE_LOG=${ENABLE_LOG:-0}
+if [ "$ENABLE_LOG" != "0" ]; then
+	set -x
+fi
 
 # get index/serial of receiver
 dev_index=$(snapctl get receiver.dump978.index)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -473,3 +473,5 @@ layout:
     bind: $SNAP_DATA/openskyd
   /etc/fonts:
     bind: $SNAP/etc/fonts
+  /var/log/rbfeeder.log:
+    bind-file: $SNAP_DATA/rbfeeder.log


### PR DESCRIPTION
Previously, most of wrapper scripts have `set -x` used, but I think that they are not always need for general users, such as #55 

This PR is to add flags to enable this kind of logs when users turn on manually.